### PR TITLE
fix bug: panic when executing some time-consuming sql task, the resp.…

### DIFF
--- a/hive/operation.go
+++ b/hive/operation.go
@@ -67,16 +67,18 @@ func (op *Operation) FetchResults(ctx context.Context, schema *TableSchema) (*Re
 	if err != nil {
 		return nil, err
 	}
-	cnt := 0
-	for resp.Results == nil {
-		select {
-		case <-ctx.Done():
-			break
-		default:
-			resp, err = fetch(ctx, op, schema)
-			cnt++
+	if ctx.Done() != nil {
+		cnt := 0
+		for resp.Results == nil {
+			select {
+			case <-ctx.Done():
+				break
+			default:
+				resp, err = fetch(ctx, op, schema)
+				cnt++
+			}
+			op.hive.log.Printf("refetch time %d\n", cnt)
 		}
-		op.hive.log.Printf("refetch time %d\n", cnt)
 	}
 	resultLen := 0
 	if resp.Results != nil {

--- a/hive/operation.go
+++ b/hive/operation.go
@@ -67,27 +67,10 @@ func (op *Operation) FetchResults(ctx context.Context, schema *TableSchema) (*Re
 	if err != nil {
 		return nil, err
 	}
-	if ctx.Done() != nil {
-		cnt := 0
-		for resp.Results == nil {
-			select {
-			case <-ctx.Done():
-				break
-			default:
-				resp, err = fetch(ctx, op, schema)
-				cnt++
-			}
-			op.hive.log.Printf("refetch time %d\n", cnt)
-		}
-	}
-	resultLen := 0
-	if resp.Results != nil {
-		resultLen = length(resp.Results)
-	}
 
 	rs := ResultSet{
 		idx:     0,
-		length:  resultLen,
+		length:  length(resp.Results),
 		result:  resp.Results,
 		more:    resp.GetHasMoreRows(),
 		schema:  schema,

--- a/hive/result_set.go
+++ b/hive/result_set.go
@@ -107,6 +107,9 @@ func value(col *cli_service.TColumn, cd *ColDesc, i int) (interface{}, error) {
 }
 
 func length(rs *cli_service.TRowSet) int {
+	if rs == nil {
+		return 0
+	}
 	for _, col := range rs.Columns {
 		if col.BoolVal != nil {
 			return len(col.BoolVal.Values)


### PR DESCRIPTION
fix bug: panic when executing some time-consuming sql task, the resp.Results that  function(operation.go) return is nil

when I execute inserting 100000+ records, panic occur, follow is traceback:
impala: 2020/12/24 22:37:57 execute operation: 63062281-d83a-4b4d-0000-00005b2e641c
impala: 2020/12/24 22:37:57 operation. has resultset: false
impala: 2020/12/24 22:37:57 operation. modified row count: 0.000000
impala: 2020/12/24 22:37:57 fetch metadata for operation: 63062281-d83a-4b4d-0000-00005b2e641c
impala: 2020/12/24 22:37:57 fetch results for operation: 63062281-d83a-4b4d-0000-00005b2e641c
impala: 2020/12/24 22:38:07 results: <nil>
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x67e305]

goroutine 1 [running]:
github.com/bippio/go-impala/hive.length(0x0, 0xc0000fe0c0)
        /Users/ipeapea/go/pkg/mod/github.com/bippio/go-impala@v2.0.1-0.20201029091501-4666eaa4ec38+incompatible/hive/result_set.go:110 +0x5
github.com/bippio/go-impala/hive.(*Operation).FetchResults(0xc0000e8020, 0x75cce0, 0xc0001ba060, 0xc00020c320, 0x0, 0x0, 0x0)
        /Users/ipeapea/go/pkg/mod/github.com/bippio/go-impala@v2.0.1-0.20201029091501-4666eaa4ec38+incompatible/hive/operation.go:73 +0xb0
github.com/bippio/go-impala.query(0x75cce0, 0xc0001ba060, 0xc00020b820, 0xc000e80000, 0x3feb3f, 0xc000e80000, 0x3feb3f, 0x0, 0xc00020edb0)
        /Users/ipeapea/go/pkg/mod/github.com/bippio/go-impala@v2.0.1-0.20201029091501-4666eaa4ec38+incompatible/statement.go:122 +0xde
github.com/bippio/go-impala.(*Conn).QueryContext(0xc00020edb0, 0x75cce0, 0xc0001ba060, 0xc000e80000, 0x3feb3f, 0x913a28, 0x0, 0x0, 0x203000, 0x33, ...)
        /Users/ipeapea/go/pkg/mod/github.com/bippio/go-impala@v2.0.1-0.20201029091501-4666eaa4ec38+incompatible/connection.go:69 +0x113
database/sql.ctxDriverQuery(0x75cce0, 0xc0001ba060, 0x7f057da1c6c0, 0xc00020edb0, 0x0, 0x0, 0xc000e80000, 0x3feb3f, 0x913a28, 0x0, ...)
        /usr/local/go/src/database/sql/ctxutil.go:48 +0x227
database/sql.(*DB).queryDC.func1()
        /usr/local/go/src/database/sql/sql.go:1643 +0x1de
database/sql.withLock(0x75a7e0, 0xc000278090, 0xc00018dbf0)
        /usr/local/go/src/database/sql/sql.go:3284 +0x69
database/sql.(*DB).queryDC(0xc00022cc30, 0x75cce0, 0xc0001ba060, 0x0, 0x0, 0xc000278090, 0xc00020a9d0, 0xc000e80000, 0x3feb3f, 0x0, ...)
        /usr/local/go/src/database/sql/sql.go:1638 +0x5f4
database/sql.(*DB).query(0xc00022cc30, 0x75cce0, 0xc0001ba060, 0xc000e80000, 0x3feb3f, 0x0, 0x0, 0x0, 0x75cc01, 0xc0001a8000, ...)
        /usr/local/go/src/database/sql/sql.go:1621 +0x136
database/sql.(*DB).QueryContext(0xc00022cc30, 0x75cce0, 0xc0001ba060, 0xc000e80000, 0x3feb3f, 0x0, 0x0, 0x0, 0x5a0e502000000c8, 0x5fe4a7c1, ...)
        /usr/local/go/src/database/sql/sql.go:1598 +0xd1