### PR TITLE
Retrying fetch when impala returns STILL_EXECUTING status

### DIFF
--- a/hive/hive.go
+++ b/hive/hive.go
@@ -28,6 +28,10 @@ func checkStatus(resp interface{}) error {
 		if status.StatusCode == cli_service.TStatusCode_INVALID_HANDLE_STATUS {
 			return errors.New("thrift: invalid handle")
 		}
+		// Impala4.0 may return this status
+		if status.StatusCode == cli_service.TStatusCode_STILL_EXECUTING_STATUS {
+			return errors.New("thrift: STILL_EXECUTING")
+		}
 
 		// SUCCESS, SUCCESS_WITH_INFO, STILL_EXECUTING are ok
 		return nil


### PR DESCRIPTION
In impala4.0, if the query execution takes too long and exceeds the FETCH_ROWS_TIMEOUT_MS time, the FetchResults rpc will return the STILL_EXECUTING status. However, since no error is thrown and no retry is performed at this time, a null pointer may appear when using the results externally. This modification retried the FetchResults rpc when the STILL_EXECUTING state occurred.