### PR TITLE
Quote string parameters in prepared statements

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -101,7 +101,11 @@ func statement(tmpl string, args []driver.NamedValue) string {
 		} else {
 			re = regexp.MustCompile(fmt.Sprintf("@p%d%s", arg.Ordinal, `\b`))
 		}
-		val := fmt.Sprintf("%v", arg.Value)
+		formatStr := "%v"
+		if _, ok := arg.Value.(string); ok {
+			formatStr = "'%v'"
+		}
+		val := fmt.Sprintf(formatStr, arg.Value)
 		stmt = re.ReplaceAllString(stmt, val)
 	}
 	return stmt

--- a/statement_test.go
+++ b/statement_test.go
@@ -7,16 +7,16 @@ import (
 
 func TestStatement(t *testing.T) {
 	tests := []struct {
-		stmt string
-		args []driver.NamedValue
-		target  string
+		stmt   string
+		args   []driver.NamedValue
+		target string
 	}{
 		{
 			stmt: "@p1 p1",
 			args: []driver.NamedValue{
 				driver.NamedValue{Ordinal: 1, Value: "val_1"},
 			},
-			target: "val_1 p1",
+			target: "'val_1' p1",
 		},
 		{
 			stmt: "@p1 @p10 @p11 @named @named1 @p1",
@@ -25,7 +25,15 @@ func TestStatement(t *testing.T) {
 				driver.NamedValue{Ordinal: 10, Name: "named", Value: "val_named"},
 				driver.NamedValue{Ordinal: 11, Value: "val_11"},
 			},
-			target: "val_1 @p10 val_11 val_named @named1 val_1",
+			target: "'val_1' @p10 'val_11' 'val_named' @named1 'val_1'",
+		},
+		{
+			stmt: "@p1 @p2",
+			args: []driver.NamedValue{
+				driver.NamedValue{Ordinal: 1, Value: "1"},
+				driver.NamedValue{Ordinal: 2, Value: 2},
+			},
+			target: "'1' 2",
 		},
 	}
 


### PR DESCRIPTION
Quotes values of string parameters in prepared statements since parameters are
normally used as values which should be quoted with single quotes.

`go test .` passes after the unit tests were adapted.